### PR TITLE
Swaps append for concat for data frame in default_geo_assignment

### DIFF
--- a/matched_markets/methodology/utils.py
+++ b/matched_markets/methodology/utils.py
@@ -256,13 +256,11 @@ def default_geo_assignment(geo_level_time_series: pd.DataFrame,
   missing_geos = list(
       set(geo_level_time_series['geo']) - set(geo_eligibility['geo']))
 
-  return geo_eligibility.append(
-      pd.DataFrame({
-          'geo': missing_geos,
-          'control': 1,
-          'treatment': 1,
-          'exclude': 1
-      })).sort_values(by='geo').reset_index(drop=True)
+  missing_df = pd.DataFrame({'geo': missing_geos, 'control': 1, 'treatment': 1, 'exclude': 1})
+
+  df = pd.concat([geo_eligibility, missing_df]).sort_values(by="geo").reset_index(drop = True)
+  return df
+
 
 
 def plot_iroas_over_time(iroas_df: pd.DataFrame, experiment_dates: pd.DataFrame,


### PR DESCRIPTION
Since pandas 2.0, `append` has been [deprecated](https://github.com/pandas-dev/pandas/issues/35407) as a method of a data frame (also https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#deprecations). This clashes with the code in `default_geo_assignment`. This PR simply swaps `append` for `concat`, should be exactly the same.